### PR TITLE
Add option to use Symfony version strategy for urlArgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 phpunit.xml
 r.js
+.idea/

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -48,6 +48,7 @@ services:
       - @hearsay_require_js.configuration_builder
       - %hearsay_require_js.initialize_template%
       - %hearsay_require_js.require_js_src%
+      - @service_container
     tags:
       - { name: templating.helper }
 

--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -95,19 +95,11 @@ class RequireJSHelper extends Helper
             'configure' => true,
         );
 
-        $options = array_merge($defaults, $options);
+        $mergedOptions = array_merge($defaults, $options);
 
         return $this->engine->render(
             $this->initializeTemplate,
-            array_merge(
-                array(
-                    'main'   => $options['main'],
-                    'config' => $options['configure']
-                        ? $this->configurationBuilder->getConfiguration()
-                        : null,
-                ),
-                array_diff_key($options, $defaults)
-            )
+            $mergedOptions
         );
     }
 


### PR DESCRIPTION
Allows using 'version_strategy' as an option instead of directly setting 'urArgs' for requirejs cache busting.
