### PR TITLE
Unset version_strategy config

### DIFF
--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -124,6 +124,8 @@ class RequireJSHelper extends Helper
         $config = $mergedOptions['config'];
         if (!array_key_exists('urlArgs', $config) && array_key_exists('version_strategy', $config)) {
             $versioningStrategyKey = $config['version_strategy'];
+            unset($config['version_strategy']);
+            
             /** @var VersionStrategyInterface $versioningStrategy */
             $versioningStrategy = $this->container->get($versioningStrategyKey);
             $urlArgs = ltrim($versioningStrategy->applyVersion(null), '?');


### PR DESCRIPTION
When using the `version_strategy` setting, it should be removed from the config in order to prevent it from being added to the RequireJS config script
