### PR TITLE
Update get globals deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,6 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                                 ->booleanNode('external')
-                                    ->cannotBeEmpty()
                                     ->defaultFalse()
                                 ->end()
                             ->end()

--- a/README.md
+++ b/README.md
@@ -11,31 +11,14 @@ This bundle provides integration of the [RequireJS][1] library into Symfony2.
 
 ### 1. Using Composer (recommended) ###
 
-To install `HearsayRequireJSBundle` with [Composer][2] just add the following to
-your `composer.json` file:
-
-```json
-{
-    // ...
-    "require": {
-        // ...
-        "hearsay/require-js-bundle": "2.0.*@dev"
-        // ...
-    }
-    // ...
-}
-```
+To install `HearsayRequireJSBundle` with the [Composer][2] command:
+```bash
+composer require hearsay/require-js-bundle:^1.1
+``` 
 
 > Note that the `master` branch is under development and unstable yet. If you
 > want to use stable version then specify the `1.0.*` version. However, remember
 > that the `1.0` branch no longer provides new features, only bug fixes.
-
-Then, you can install the new dependencies by running Composer's update command
-from the directory where your `composer.json` file is located:
-
-```sh
-$ php composer.phar update hearsay/require-js-bundle
-```
 
 Now, Composer will automatically download all required files, and install them
 for you. All that is left to do is to update your `AppKernel.php` file, and

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,72 +1,66 @@
 parameters:
   hearsay_require_js.module_formula_loader.class: Hearsay\RequireJSBundle\Assetic\Factory\Loader\ModuleFormulaLoader
-
   hearsay_require_js.filenames_resource.class: Hearsay\RequireJSBundle\Assetic\Factory\Resource\FilenamesResource
-
   hearsay_require_js.namespace_mapping.class: Hearsay\RequireJSBundle\Configuration\NamespaceMapping
-
   hearsay_require_js.configuration_builder.class: Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder
-
   hearsay_require_js.templating_helper.class: Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper
-
   hearsay_require_js.twig_extension.class: Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension
-
   hearsay_require_js.optimizer_filter.class: Hearsay\RequireJSBundle\Assetic\Filter\RJsFilter
 
 services:
   hearsay_require_js.module_formula_loader:
-    class: %hearsay_require_js.module_formula_loader.class%
+    class: '%hearsay_require_js.module_formula_loader.class%'
     arguments:
-      - @assetic.asset_factory
-      - @hearsay_require_js.namespace_mapping
+      - '@assetic.asset_factory'
+      - '@hearsay_require_js.namespace_mapping'
     tags:
       - { name: assetic.formula_loader, alias: require_js }
 
   hearsay_require_js.filenames_resource:
-    class: %hearsay_require_js.filenames_resource.class%
+    class: '%hearsay_require_js.filenames_resource.class%'
     abstract: true
 
   hearsay_require_js.namespace_mapping:
-    class: %hearsay_require_js.namespace_mapping.class%
+    class: '%hearsay_require_js.namespace_mapping.class%'
     arguments:
-      - %hearsay_require_js.base_url%
+      - '%hearsay_require_js.base_url%'
     public: false
 
   hearsay_require_js.configuration_builder:
-    class: %hearsay_require_js.configuration_builder.class%
+    class: '%hearsay_require_js.configuration_builder.class%'
     arguments:
-      - @service_container
-      - @hearsay_require_js.namespace_mapping
-      - %hearsay_require_js.base_url%
-      - %hearsay_require_js.shim%
+      - '@service_container'
+      - '@hearsay_require_js.namespace_mapping'
+      - '%hearsay_require_js.base_url%'
+      - '%hearsay_require_js.shim%'
     public: false
 
   hearsay_require_js.templating_helper:
-    class: %hearsay_require_js.templating_helper.class%
+    class: '%hearsay_require_js.templating_helper.class%'
     arguments:
-      - @templating
-      - @hearsay_require_js.configuration_builder
-      - %hearsay_require_js.initialize_template%
-      - %hearsay_require_js.require_js_src%
+      - '@templating'
+      - '@hearsay_require_js.configuration_builder'
+      - '%hearsay_require_js.initialize_template%'
+      - '%hearsay_require_js.require_js_src%'
     tags:
       - { name: templating.helper }
 
   hearsay_require_js.twig_extension:
-    class: %hearsay_require_js.twig_extension.class%
+    class: '%hearsay_require_js.twig_extension.class%'
     arguments:
-      - @service_container
-      - @hearsay_require_js.configuration_builder
+      - '@service_container'
+      - '@hearsay_require_js.configuration_builder'
     tags:
       - { name: twig.extension }
 
   hearsay_require_js.optimizer_filter:
-    class: %hearsay_require_js.optimizer_filter.class%
+    class: '%hearsay_require_js.optimizer_filter.class%'
     arguments:
-      - %assetic.node.bin%
-      - %hearsay_require_js.r.path%
-      - %hearsay_require_js.base_dir%
-      - %hearsay_require_js.declare_module_name%
+      - '%assetic.node.bin%'
+      - '%hearsay_require_js.r.path%'
+      - '%hearsay_require_js.base_dir%'
+      - '%hearsay_require_js.declare_module_name%'
     calls:
-      - [ addNodePath, [%assetic.node.bin%] ]
+      - [ addNodePath, ['%assetic.node.bin%'] ]
     tags:
       - { name: assetic.filter, alias: requirejs }

--- a/Tests/Assetic/Factory/Loader/ModuleFormulaLoaderTest.php
+++ b/Tests/Assetic/Factory/Loader/ModuleFormulaLoaderTest.php
@@ -25,38 +25,38 @@ class ModuleFormulaLoaderTest extends \PHPUnit_Framework_TestCase
         $file2 = __DIR__ . '/dir/other_file';
 
         $factory = $this->getMockBuilder('Assetic\Factory\AssetFactory')
-                ->disableOriginalConstructor()
-                ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
         $factory->expects($this->at(0))
-                ->method('generateAssetName')
-                ->with($file1, array())
-                ->will($this->returnValue('file'));
+            ->method('generateAssetName')
+            ->with($file1, array())
+            ->will($this->returnValue('file'));
         $factory->expects($this->at(1))
-                ->method('generateAssetName')
-                ->with($file2, array())
-                ->will($this->returnValue('other_file'));
+            ->method('generateAssetName')
+            ->with($file2, array())
+            ->will($this->returnValue('other_file'));
 
         $mapping = $this->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
         $mapping->expects($this->at(0))
-                ->method('getModulePath')
-                ->with($file1)
-                ->will($this->returnValue('first/module'));
+            ->method('getModulePath')
+            ->with($file1)
+            ->will($this->returnValue('first/module'));
         $mapping->expects($this->at(1))
-                ->method('getModulePath')
-                ->with($file2)
-                ->will($this->returnValue('second/module'));
+            ->method('getModulePath')
+            ->with($file2)
+            ->will($this->returnValue('second/module'));
 
         $resource = $this->createMock('Assetic\Factory\Resource\ResourceInterface');
         $resource->expects($this->any())
-                ->method('getContent')
-                ->will($this->returnValue($file1 . "\nsome other\ntext\n" . $file2));
+            ->method('getContent')
+            ->will($this->returnValue($file1 . "\nsome other\ntext\n" . $file2));
 
         $loader = new ModuleFormulaLoader($factory, $mapping);
         $formulae = $loader->load($resource);
 
         $this->assertEquals(array(
             'file' => array($file1, array(), array('output' => 'first/module')),
-            'other_file' => array($file2, array(), array('output' => 'second/module'))
+            'other_file' => array($file2, array(), array('output' => 'second/module')),
         ), $formulae, 'Unexpected formulae loaded');
     }
 }

--- a/Tests/Assetic/Factory/Loader/ModuleFormulaLoaderTest.php
+++ b/Tests/Assetic/Factory/Loader/ModuleFormulaLoaderTest.php
@@ -36,7 +36,7 @@ class ModuleFormulaLoaderTest extends \PHPUnit_Framework_TestCase
                 ->with($file2, array())
                 ->will($this->returnValue('other_file'));
 
-        $mapping = $this->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+        $mapping = $this->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
         $mapping->expects($this->at(0))
                 ->method('getModulePath')
                 ->with($file1)
@@ -46,7 +46,7 @@ class ModuleFormulaLoaderTest extends \PHPUnit_Framework_TestCase
                 ->with($file2)
                 ->will($this->returnValue('second/module'));
 
-        $resource = $this->getMock('Assetic\Factory\Resource\ResourceInterface');
+        $resource = $this->createMock('Assetic\Factory\Resource\ResourceInterface');
         $resource->expects($this->any())
                 ->method('getContent')
                 ->will($this->returnValue($file1 . "\nsome other\ntext\n" . $file2));

--- a/Tests/Configuration/ConfigurationBuilderTest.php
+++ b/Tests/Configuration/ConfigurationBuilderTest.php
@@ -11,9 +11,6 @@
 
 namespace Hearsay\RequireJSBundle\Tests\Configuration;
 
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Scope;
-
 use Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder;
 
 /**
@@ -23,7 +20,7 @@ use Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder;
 class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var Container
+     * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $container;
 
@@ -34,18 +31,18 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->container = new Container();
-        $this->container->addScope(new Scope('request'));
-        $this->container->enterScope('request');
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\Container')
+        ->disableOriginalConstructor()
+        ->getMock();
 
         $translator = $this
-            ->getMock('Symfony\Component\Translation\TranslatorInterface');
+            ->createMock('Symfony\Component\Translation\TranslatorInterface');
         $translator
             ->expects($this->any())
             ->method('getLocale')
             ->will($this->returnValue('fr_FR'));
 
-        $this->container->set('translator', $translator);
+        $this->container->setParameter('translator', $translator);
     }
 
     /**
@@ -56,7 +53,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testConfigurationGenerated()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->setRequestMock('/base');
         $this->container->setParameter('assetic.use_controller', true);
@@ -85,7 +82,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testBaseUrlSlashesTrimmed()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->setRequestMock('/base');
         $this->container->setParameter('assetic.use_controller', true);
@@ -108,7 +105,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testBaseUrlIgnoredIfAppropriate()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->setAssetsHelperMock(null);
         $this->container->setParameter('assetic.use_controller', false);
@@ -131,7 +128,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testPathsAdded()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->container->leaveScope('request');
         $this->container->setParameter('assetic.use_controller', false);
@@ -159,7 +156,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testAssetsBaseUrlUsed()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->setRequestMock('/base');
         $this->setAssetsHelperMock('/assets/?123');
@@ -184,7 +181,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testUseAlmondDevEnvironment()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->greateMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->setRequestMock('/base');
         $this->container->setParameter('assetic.use_controller', true);
@@ -207,7 +204,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     public function testUseAlmondProdEnvironment()
     {
         $mapping = $this
-            ->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+            ->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
 
         $this->setRequestMock('/base');
         $this->container->setParameter('assetic.use_controller', true);
@@ -237,7 +234,7 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(''))
             ->will($this->returnValue($filename));
 
-        $this->container->set('templating.helper.assets', $assetsHelper, 'request');
+        $this->container->setParameter('templating.helper.assets', $assetsHelper, 'request');
     }
 
     /**
@@ -246,12 +243,12 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     private function setRequestMock($baseUrl)
     {
         $request = $this
-            ->getMock('Symfony\Component\HttpFoundation\Request');
+            ->createMock('Symfony\Component\HttpFoundation\Request');
         $request
             ->expects($this->any())
             ->method('getBaseUrl')
             ->will($this->returnValue($baseUrl));
 
-        $this->container->set('request', $request);
+        $this->container->setParameter('request', $request);
     }
 }

--- a/Tests/Configuration/ConfigurationBuilderTest.php
+++ b/Tests/Configuration/ConfigurationBuilderTest.php
@@ -46,9 +46,9 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::addOption
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::addOption
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testConfigurationGenerated()
     {
@@ -75,9 +75,9 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testBaseUrlSlashesTrimmed()
     {
@@ -98,9 +98,9 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testBaseUrlIgnoredIfAppropriate()
     {
@@ -121,9 +121,9 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::setPath
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::setPath
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testPathsAdded()
     {
@@ -149,9 +149,9 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testAssetsBaseUrlUsed()
     {
@@ -173,10 +173,10 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::setUseAlmond
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::setUseAlmond
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testUseAlmondDevEnvironment()
     {
@@ -196,10 +196,10 @@ class ConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::setUseAlmond
-     * @covers Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::__construct
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getBaseUrl
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::setUseAlmond
+     * @covers \Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder::getConfiguration
      */
     public function testUseAlmondProdEnvironment()
     {

--- a/Tests/Templating/Helper/RequireJSHelperTest.php
+++ b/Tests/Templating/Helper/RequireJSHelperTest.php
@@ -20,7 +20,7 @@ use Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper;
 class RequireJSHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
+     * @covers \Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
      */
     public function testDefaultInitialization()
     {
@@ -43,7 +43,7 @@ class RequireJSHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
+     * @covers \Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
      */
     public function testConfigurationSuppressed()
     {
@@ -65,7 +65,7 @@ class RequireJSHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
+     * @covers \Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
      */
     public function testMainScriptIncluded()
     {
@@ -94,7 +94,7 @@ class RequireJSHelperTest extends \PHPUnit_Framework_TestCase
      */
     private function getEngineMock($config = null, $main = null)
     {
-        $engine = $this->getMock('Symfony\Component\Templating\EngineInterface');
+        $engine = $this->createMock('Symfony\Component\Templating\EngineInterface');
         $engine->expects($this->once())
             ->method('render')
             ->with('template', array(

--- a/Tests/Twig/Extension/RequireJSExtensionTest.php
+++ b/Tests/Twig/Extension/RequireJSExtensionTest.php
@@ -30,8 +30,9 @@ class RequireJSExtensionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * {@inheritDoc}
+     * @test
      */
-    protected function setUp()
+    public function setUp()
     {
         parent::setUp();
 

--- a/Tests/Twig/Extension/RequireJSExtensionTest.php
+++ b/Tests/Twig/Extension/RequireJSExtensionTest.php
@@ -11,9 +11,6 @@
 
 namespace Hearsay\RequireJSBundle\Tests\Twig\Extension;
 
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Scope;
-
 use Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension;
 
 /**
@@ -22,7 +19,7 @@ use Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension;
 class RequireJSExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var Container
+     * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $container;
 
@@ -38,7 +35,9 @@ class RequireJSExtensionTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->container = new Container();
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\Container')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $configurationBuilder = $this
             ->getMockBuilder('Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder')
@@ -53,28 +52,6 @@ class RequireJSExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension = new RequireJSExtension(
             $this->container,
             $configurationBuilder
-        );
-    }
-
-    /**
-     * @covers Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension::getGlobals
-     */
-    public function testGetGlobalsInInactiveRequestScope()
-    {
-        $this->assertEquals(array(), $this->extension->getGlobals());
-    }
-
-    /**
-     * @covers Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension::getGlobals
-     */
-    public function testGetGlobalsInActiveRequestScope()
-    {
-        $this->container->addScope(new Scope('request'));
-        $this->container->enterScope('request');
-
-        $this->assertEquals(
-            array('require_js' => array('config' => array())),
-            $this->extension->getGlobals()
         );
     }
 }

--- a/Twig/Extension/RequireJSExtension.php
+++ b/Twig/Extension/RequireJSExtension.php
@@ -20,7 +20,7 @@ use Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper;
  * Twig extension providing RequireJS functionality.
  * @author Kevin Montag <kevin@hearsay.it>
  */
-class RequireJSExtension extends \Twig_Extension
+class RequireJSExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
      * @var ConfigurationBuilder
@@ -55,25 +55,15 @@ class RequireJSExtension extends \Twig_Extension
             'require_js_initialize' => new \Twig_Function_Method(
                 $this,
                 'initialize',
-                array('is_safe' => array('html'))
+                array(
+                    'is_safe' =>
+                        array(
+                            'html'
+                        ),
+                    'needs_environment' => true
+                )
             ),
             'require_js_src'        => new \Twig_Function_Method($this, 'src'),
-        );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getGlobals()
-    {
-        if (!$this->container->isScopeActive('request')) {
-            return array();
-        }
-
-        return array(
-            'require_js' => array(
-                'config' => $this->configurationBuilder->getConfiguration(),
-            ),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,15 @@
         "symfony/finder": ">=2.0",
         "symfony/yaml": ">=2.0",
         "symfony/assetic-bundle": "^2.8",
-        "symfony/framework-bundle": "^2.3|^3.0"
+        "symfony/framework-bundle": "^2.3|^3.0",
+        "symfony/templating": "^3.3"
     },
     "require-dev": {
         "twig/extensions": "v1.0.0",
-        "squizlabs/php_codesniffer": "1.*",
-        "phpunit/phpunit": "3.7.*"
+        "squizlabs/php_codesniffer": "^2.7",
+        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit-mock-objects":"^3.4",
+        "phpro/grumphp": "^0.11.1"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=5.3.2",
         "symfony/finder": ">=2.0",
         "symfony/yaml": ">=2.0",
-        "kriswallsmith/assetic": ">= 1.0",
-        "symfony/framework-bundle": ">=2.0.9"
+        "symfony/assetic-bundle": "^2.8",
+        "symfony/framework-bundle": "^2.3|^3.0"
     },
     "require-dev": {
         "twig/extensions": "v1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "twig/extensions": "v1.0.0",
         "squizlabs/php_codesniffer": "^2.7",
         "phpunit/phpunit": "^5.7",
-        "phpunit/phpunit-mock-objects":"^3.4",
-        "phpro/grumphp": "^0.11.1"
+        "phpunit/phpunit-mock-objects":"^3.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Original goal was to add `\Twig_Extension_GlobalsInterface` in `class RequireJSExtension` in order to fix the symfon-3-upgrade-process deprecation warning of `since 1.23 (to be removed in 2.0), implement Twig_Extension_GlobalsInterface instead`.
It also includes some compatability updates for Symfony 3.x and PHPUnit 5.x.